### PR TITLE
Bump game-ci/unity-test-runner from 3.0.0 to 3.1.0 (#12)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,7 @@ jobs:
         uses: ./.github/actions/checkout
 
       - name: Unity - Run tests
-        uses: game-ci/unity-test-runner@v3.0.0
+        uses: game-ci/unity-test-runner@v3.1.0
         env:
           UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
           UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}


### PR DESCRIPTION
clone of #12 
Bumps [game-ci/unity-test-runner](https://github.com/game-ci/unity-test-runner) from 3.0.0 to 3.1.0.
- [Release notes](https://github.com/game-ci/unity-test-runner/releases)
- [Commits](https://github.com/game-ci/unity-test-runner/compare/v3.0.0...v3.1.0)

---
updated-dependencies:
- dependency-name: game-ci/unity-test-runner dependency-type: direct:production update-type: version-update:semver-minor ...