### PR TITLE
chore: update Unity packages (com.unity.ide.visualstudio to 2.0.23, com.unity.settings-manager to 2.1.0)

### DIFF
--- a/src/UnityVisualStudioSolutionGenerator/Assets/package.json
+++ b/src/UnityVisualStudioSolutionGenerator/Assets/package.json
@@ -12,8 +12,8 @@
         "name": "JoC0de"
     },
     "dependencies": {
-        "com.unity.ide.visualstudio": "2.0.22",
-        "com.unity.settings-manager": "2.0.1"
+        "com.unity.ide.visualstudio": "2.0.23",
+        "com.unity.settings-manager": "2.1.0"
     },
     "license": "MIT",
     "licensesUrl": "https://github.com/JoC0de/UnityVisualStudioSolutionGenerator/blob/main/LICENSE",

--- a/src/UnityVisualStudioSolutionGenerator/Packages/manifest.json
+++ b/src/UnityVisualStudioSolutionGenerator/Packages/manifest.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
-    "com.unity.ide.visualstudio": "2.0.22",
-    "com.unity.settings-manager": "2.0.1",
+    "com.unity.ide.visualstudio": "2.0.23",
+    "com.unity.settings-manager": "2.1.0",
     "com.unity.modules.accessibility": "1.0.0"
   }
 }


### PR DESCRIPTION
This pull request updates the following Unity packages to their latest versions:

com.unity.ide.visualstudio: 2.0.22 → 2.0.23
com.unity.settings-manager: 2.0.1 → 2.1.0