### PR TITLE
Allow Dependabot PR to run GitHub Action

### DIFF
--- a/.github/actions/checkout/action.yml
+++ b/.github/actions/checkout/action.yml
@@ -30,7 +30,8 @@ runs:
       if: |
         github.event_name == 'pull_request_target' &&
         steps.changedWorkflowFiles.outputs.any_changed == 'true' &&
-        github.event.pull_request.user.login != 'JoC0de'
+        github.event.pull_request.user.login != 'JoC0de' &&
+        github.event.pull_request.user.login != 'dependabot[bot]'
       shell: bash
       run: |
         echo "One or more files in the .github folder has changed."


### PR DESCRIPTION
Allow the GitHub Action code created by dependabot to be run even if it  change files inside .github directory