### PR TITLE
Configure GitHub Action to run Dependapot actions directly (fix)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - "main"
-      - "dependabot/github_actions/*"
+      - "dependabot/github_actions/**"
     tags: ["v*"]
   pull_request_target:
     branches: ["main"]
@@ -23,10 +23,12 @@ jobs:
       github.event_name != 'pull_request_target' ||
       !startsWith(github.head_ref, 'dependabot/github_actions/')
     steps:
-      - name: Checkout action file
-        uses: Bhacaz/checkout-files@v2
+      - name: Checkout only action file
+        uses: actions/checkout@v4
         with:
-          files: .github/actions/checkout/action.yml
+          sparse-checkout: |
+            .github/actions/checkout/action.yml
+          fetch-depth: 1
 
       - name: Checkout
         uses: ./.github/actions/checkout


### PR DESCRIPTION
also remove `Bhacaz/checkout-files@v2` in favor of using `sparse-checkout`